### PR TITLE
chore: rename `socket` to `tcp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ wait-on file /path/to/file
 ### Wait for a Socket to be available using TCP Protocol
 
 ```bash
-wait-on socket -i 127.0.0.1 -p 8080
+wait-on tcp -i 127.0.0.1 -p 8080
 ```
 
 ## License

--- a/src/bin/command/mod.rs
+++ b/src/bin/command/mod.rs
@@ -1,2 +1,2 @@
 pub mod file;
-pub mod socket;
+pub mod tcp;

--- a/src/bin/command/tcp.rs
+++ b/src/bin/command/tcp.rs
@@ -3,20 +3,20 @@ use std::net::IpAddr;
 use anyhow::Result;
 use clap::Args;
 
-use wait_on::resource::socket::SocketWaiter;
+use wait_on::resource::tcp::TcpWaiter;
 use wait_on::{WaitOptions, Waitable};
 
 #[derive(Args, Debug)]
-pub struct SocketOpt {
+pub struct TcpOpt {
     #[clap(short = 'p', long = "port")]
     pub port: u16,
     #[clap(short = 'i', long = "ip", default_value = "127.0.0.1")]
     pub addr: IpAddr,
 }
 
-impl SocketOpt {
+impl TcpOpt {
     pub async fn exec(&self) -> Result<()> {
-        let waiter = SocketWaiter::new(self.addr, self.port);
+        let waiter = TcpWaiter::new(self.addr, self.port);
         waiter.wait(WaitOptions::default()).await
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use self::command::file::FileOpt;
-use self::command::socket::SocketOpt;
+use self::command::tcp::TcpOpt;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -16,8 +16,8 @@ use self::command::socket::SocketOpt;
 pub enum Command {
     /// Wait on a file to be available
     File(FileOpt),
-    /// Wait on a socket to be available using the TCP Protocol
-    Socket(SocketOpt),
+    /// Wait on a TCP connection to be available
+    Tcp(TcpOpt),
 }
 
 #[derive(Debug, Parser)]
@@ -32,6 +32,6 @@ async fn main() -> Result<()> {
 
     match args.command {
         Command::File(opt) => opt.exec().await,
-        Command::Socket(opt) => opt.exec().await,
+        Command::Tcp(opt) => opt.exec().await,
     }
 }

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -2,25 +2,25 @@
 //! own configuration based on the protocols used.
 
 pub mod file;
-pub mod socket;
+pub mod tcp;
 
 use anyhow::Result;
 
 use crate::{WaitOptions, Waitable};
 
 use self::file::FileWaiter;
-use self::socket::SocketWaiter;
+use self::tcp::TcpWaiter;
 
 pub enum Resource {
     File(FileWaiter),
-    Socket(SocketWaiter),
+    Tcp(TcpWaiter),
 }
 
 impl Waitable for Resource {
     async fn wait(self, options: WaitOptions) -> Result<()> {
         match self {
             Resource::File(file) => file.wait(options).await,
-            Resource::Socket(socket) => socket.wait(options).await,
+            Resource::Tcp(tcp) => tcp.wait(options).await,
         }
     }
 }


### PR DESCRIPTION
Uses `socket` over `tcp` so `socket` is reserved for Unix domain sockets.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
